### PR TITLE
Fix upside-down photos on Nexus 5X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ gen/
 .idea_modules
 target/
 libmmcamera_imx179_mod/imx179_patch
+project/build.properties

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
           package="pkmx.lcamera"
           android:versionCode="3"
           android:versionName="0.3">
@@ -12,7 +13,8 @@
     <application android:label="L Camera"
                  android:icon="@drawable/ic_launcher"
                  android:theme="@android:style/Theme.Material.NoActionBar.Fullscreen"
-                 android:allowBackup="true">
+                 android:allowBackup="true"
+                 tools:replace="android:label">
         <activity android:name=".MainActivity"
                   android:screenOrientation="portrait">
             <intent-filter>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Screenshot](screenshot.jpg?raw=true)
 
-**L Camera** is an open-source experimental camera app for Android L devices using the new `android.hardware.camera2` API. Currently, the only supported device is Nexus 5 and Nexus 6 running Android 5.0 Lollipop.
+**L Camera** is an open-source experimental camera app for Android L (and newer) devices using the new `android.hardware.camera2` API. Currently, supported devices include Nexus 5, 6, 5X and 6P running Android 5.0 Lollipop and 6.0 Marshmallow.
 
 *Please note that this app is intended to test and study new features of the camera API, it is not for general uses as it lacks many basic camera features (location tagging, white balance, photo review, flash control, etc).*
 
@@ -116,15 +116,17 @@ The app is written in the [Scala](http://www.scala-lang.org/) programming langua
 
 ### How to build
 
-You must have both **scala 2.11.5** and **sbt >= 0.13** installed.
+You must have both **scala 2.11.8** and **sbt >= 0.13** installed.
+Also, you must ensure that sbt runs with JDK 7, not 8.
+For example, `sbt -java-home `/usr/libexec/java_home -v 1.7` on OS X.
 
 To build the app (the resulting APK will be placed in the `bin/` directory):
 
-    $ sbt package
+    $ sbt android:package
 
 To build and run the app on device (assuming you have `adb` and developer mode enabled):
 
-    $ sbt run
+    $ sbt android:run
 
 ### Debugging
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,9 @@
 import android.Keys._
 import android.Dependencies.aar
 
-android.Plugin.androidBuild
-
 name := "lcamera"
 
-scalaVersion := "2.11.5"
+scalaVersion := "2.11.8"
 
 resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
 
@@ -20,9 +18,9 @@ libraryDependencies ++= Seq(
 platformTarget in Android := "android-21"
 
 proguardCache in Android ++=
-  Seq ( ProguardCache("org.scaloid") % "org.scaloid" %% "scaloid"
-      , ProguardCache("rx") % "com.scalarx" %% "scalarx"
-      , ProguardCache("akka") % "com.typesafe.akka" %% "akka-actor"
+  Seq ( "org.scaloid.scaloid"
+      , "com.scalarx.scalarx"
+      , "com.typesafe.akka.akka-actor"
       )
 
 proguardOptions in Android ++=
@@ -33,10 +31,12 @@ proguardOptions in Android ++=
       , "-dontwarn sun.misc.Unsafe"
       )
 
-scalacOptions in Compile ++= Seq("-feature", "-deprecation", "-Xlint", "-Xfuture", "-Ywarn-dead-code", "-Ywarn-unused")
+scalacOptions ++= Seq("-target:jvm-1.7", "-feature", "-deprecation", "-Xlint", "-Xfuture", "-Ywarn-dead-code", "-Ywarn-unused")
+
+javacOptions ++= Seq("-source", "1.7")
 
 run <<= run in Android
 
 install <<= install in Android
 
-Keys.`package` <<= `packageT` in Android
+//Keys.`package` <<= `packageT` in Android

--- a/project/build.scala
+++ b/project/build.scala
@@ -1,0 +1,1 @@
+object Build extends android.AutoBuild

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
-addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.3.5")
+addSbtPlugin("org.scala-android" % "sbt-android" % "1.6.3")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.7.0-SNAPSHOT")
 
-libraryDependencies += "net.sf.proguard" % "proguard-base" % "5.0"
+libraryDependencies += "net.sf.proguard" % "proguard-base" % "5.2.1"


### PR DESCRIPTION
Use the sensor's rotation from the API instead of hard-coded values for older Nexus phones. #174

Also update build stuff. I'm not sure what `Keys.``package``<<=``packageT``in Android` did – it returned an error for me: `packageT` doesn't exist.
